### PR TITLE
new: Support `@link` tokens in markdown.

### DIFF
--- a/packages/plugin/src/components/Markdown.tsx
+++ b/packages/plugin/src/components/Markdown.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from 'react';
 import marked, { TokensList } from 'marked';
 import MDX from '@theme/MDXComponents';
+import { useReflectionMap } from '../hooks/useReflectionMap';
+import { replaceLinkTokens } from '../utils/markdown';
 
 marked.setOptions({
 	gfm: true,
@@ -161,7 +163,8 @@ export interface MarkdownProps {
 
 // Too bad we cant use `@mdx-js` here...
 export function Markdown({ content }: MarkdownProps) {
-	const [ast] = useState<TokensList>(() => marked.lexer(content));
+	const reflections = useReflectionMap();
+	const [ast] = useState<TokensList>(() => marked.lexer(replaceLinkTokens(content, reflections)));
 
 	if (!content) {
 		return null;

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -94,7 +94,7 @@ export default function typedocApiPlugin(
 		return {
 			absolutePath,
 			entryPoints: entries,
-			packagePath: pkgConfig.path ?? '.',
+			packagePath: pkgConfig.path || '.',
 			packageSlug: pkgConfig.slug ?? path.basename(absolutePath),
 		};
 	});

--- a/packages/plugin/src/utils/markdown.ts
+++ b/packages/plugin/src/utils/markdown.ts
@@ -1,3 +1,4 @@
+import type { JSONOutput } from 'typedoc';
 import { DeclarationReflectionMap } from '../types';
 
 function splitLinkText(text: string): { caption: string; target: string } {
@@ -23,24 +24,38 @@ function splitLinkText(text: string): { caption: string; target: string } {
 	};
 }
 
+function findReflectionWithMatchingTarget(
+	reflectionList: JSONOutput.DeclarationReflection[],
+	symbol: string,
+	member: string,
+) {
+	return reflectionList.find((ref) => {
+		if (ref.name !== symbol) {
+			return false;
+		}
+
+		return member === '' ? true : ref.children?.some((child) => child.name === member);
+	});
+}
+
 // TypeDoc JSON output does not replace links, so we need to do this manually.
 // @see https://github.com/TypeStrong/typedoc/blob/master/src/lib/output/plugins/MarkedLinksPlugin.ts
 export function replaceLinkTokens(markdown: string, reflections: DeclarationReflectionMap) {
 	const reflectionList = Object.values(reflections);
 
 	return markdown.replace(
-		// eslint-disable-next-line unicorn/no-unsafe-regex
-		/(?:\[(.+?)])?{@(link|linkcode|linkplain)\s+([\n.]+?)}/gi,
-		(match: string, leading: string, tagName: string, content: string): string => {
+		/{@(link|linkcode|linkplain)\s+([^}]+?)}/gi,
+		(match: string, tagName: string, content: string): string => {
 			const { caption, target } = splitLinkText(content);
 			const [symbol, member = ''] = target.split('.');
-			const reflection = reflectionList.find((ref) => ref.name === symbol);
+			const reflection = findReflectionWithMatchingTarget(reflectionList, symbol, member);
+			const label = tagName === 'linkcode' ? `\`${caption}\`` : caption;
 
 			if (!reflection || !reflection.permalink) {
-				return `\`${target}\``;
+				return label;
 			}
 
-			return `[${leading || caption}](${reflection.permalink}${member ? `#${member}` : ''})`;
+			return `[${label}](${reflection.permalink}${member ? `#${member}` : ''})`;
 		},
 	);
 }

--- a/packages/plugin/src/utils/markdown.ts
+++ b/packages/plugin/src/utils/markdown.ts
@@ -1,0 +1,46 @@
+import { DeclarationReflectionMap } from '../types';
+
+function splitLinkText(text: string): { caption: string; target: string } {
+	let splitIndex = text.indexOf('|');
+
+	if (splitIndex === -1) {
+		splitIndex = text.search(/\s/);
+	}
+
+	if (splitIndex !== -1) {
+		return {
+			caption: text
+				.slice(splitIndex + 1)
+				.replace(/\n+/, ' ')
+				.trim(),
+			target: text.slice(0, Math.max(0, splitIndex)).trim(),
+		};
+	}
+
+	return {
+		caption: text,
+		target: text,
+	};
+}
+
+// TypeDoc JSON output does not replace links, so we need to do this manually.
+// @see https://github.com/TypeStrong/typedoc/blob/master/src/lib/output/plugins/MarkedLinksPlugin.ts
+export function replaceLinkTokens(markdown: string, reflections: DeclarationReflectionMap) {
+	const reflectionList = Object.values(reflections);
+
+	return markdown.replace(
+		// eslint-disable-next-line unicorn/no-unsafe-regex
+		/(?:\[(.+?)])?{@(link|linkcode|linkplain)\s+([\n.]+?)}/gi,
+		(match: string, leading: string, tagName: string, content: string): string => {
+			const { caption, target } = splitLinkText(content);
+			const [symbol, member = ''] = target.split('.');
+			const reflection = reflectionList.find((ref) => ref.name === symbol);
+
+			if (!reflection || !reflection.permalink) {
+				return `\`${target}\``;
+			}
+
+			return `[${leading || caption}](${reflection.permalink}${member ? `#${member}` : ''})`;
+		},
+	);
+}

--- a/packages/plugin/src/utils/markdown.ts
+++ b/packages/plugin/src/utils/markdown.ts
@@ -27,14 +27,14 @@ function splitLinkText(text: string): { caption: string; target: string } {
 function findReflectionWithMatchingTarget(
 	reflectionList: JSONOutput.DeclarationReflection[],
 	symbol: string,
-	member: string,
+	member?: string,
 ) {
 	return reflectionList.find((ref) => {
 		if (ref.name !== symbol) {
 			return false;
 		}
 
-		return member === '' ? true : ref.children?.some((child) => child.name === member);
+		return !member ? true : ref.children?.some((child) => child.name === member);
 	});
 }
 
@@ -47,7 +47,7 @@ export function replaceLinkTokens(markdown: string, reflections: DeclarationRefl
 		/{@(link|linkcode|linkplain)\s+([^}]+?)}/gi,
 		(match: string, tagName: string, content: string): string => {
 			const { caption, target } = splitLinkText(content);
-			const [symbol, member = ''] = target.split('.');
+			const [symbol, member] = target.split('.');
 			const reflection = findReflectionWithMatchingTarget(reflectionList, symbol, member);
 			const label = tagName === 'linkcode' ? `\`${caption}\`` : caption;
 


### PR DESCRIPTION
We have to handle this manually unfortunately.

Fixes #9 