### PR TITLE
new: Add `gitRefName` option.

### DIFF
--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -83,6 +83,7 @@ The following options are available to the plugin:
 - `banner` (`string`) - Banner message to display at the top of the index page. Supports HTML.
 - `exclude` (`string[]`) - List of glob patterns to exclude unwanted packages. This is necessary
   when using TypeScript project references.
+- `gitRefName` (`string`) - GitHub repository ref name to point the API links to. Defaults to `master`.
 - `minimal` (`boolean`) - Render a minimal layout and reduce the amount of information displayed.
   Defaults to `false`.
 - `packageJsonName` (`string`) - Name of the `package.json file`. Defaults to `package.json`.

--- a/packages/plugin/src/components/ApiDataContext.ts
+++ b/packages/plugin/src/components/ApiDataContext.ts
@@ -5,6 +5,6 @@ export const ApiDataContext = createContext<{
 	options: ApiOptions;
 	reflections: DeclarationReflectionMap;
 }>({
-	options: { banner: '', breadcrumbs: true, minimal: false, pluginId: 'default', scopes: [] },
+	options: { banner: '', breadcrumbs: true, gitRefName: 'master', minimal: false, pluginId: 'default', scopes: [] },
 	reflections: {},
 });

--- a/packages/plugin/src/components/SourceLink.tsx
+++ b/packages/plugin/src/components/SourceLink.tsx
@@ -1,15 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import type { JSONOutput } from 'typedoc';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { ApiDataContext } from './ApiDataContext';
+import { useGitRefName } from '../hooks/useGitRefName';
 
 function replaceWithSrc(url: string): string {
 	// Always link the source file
 	return url.replace(/\/(dts|dist|lib|build|es|esm|cjs|mjs)\//, '/src/');
-}
-
-export function useGitRefName(): string {
-	return useContext(ApiDataContext).options.gitRefName;
 }
 
 export interface SourceLinkProps {

--- a/packages/plugin/src/components/SourceLink.tsx
+++ b/packages/plugin/src/components/SourceLink.tsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import type { JSONOutput } from 'typedoc';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { ApiDataContext } from './ApiDataContext';
 
 function replaceWithSrc(url: string): string {
 	// Always link the source file
 	return url.replace(/\/(dts|dist|lib|build|es|esm|cjs|mjs)\//, '/src/');
+}
+
+export function useGitRefName(): string {
+	return useContext(ApiDataContext).options.gitRefName;
 }
 
 export interface SourceLinkProps {
@@ -13,6 +18,7 @@ export interface SourceLinkProps {
 
 export function SourceLink({ sources = [] }: SourceLinkProps) {
 	const { siteConfig } = useDocusaurusContext();
+	const gitRefName = useGitRefName();
 
 	if (sources.length === 0) {
 		return null;
@@ -26,7 +32,7 @@ export function SourceLink({ sources = [] }: SourceLinkProps) {
 					className="tsd-anchor"
 					href={`https://github.com/${siteConfig.organizationName}/${
 						siteConfig.projectName
-					}/blob/master/${replaceWithSrc(source.fileName)}#L${source.line}`}
+					}/blob/${gitRefName}/${replaceWithSrc(source.fileName)}#L${source.line}`}
 					rel="noreferrer"
 					target="_blank"
 				>

--- a/packages/plugin/src/hooks/useGitRefName.ts
+++ b/packages/plugin/src/hooks/useGitRefName.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ApiDataContext } from '../components/ApiDataContext';
+
+export function useGitRefName(): string {
+    return useContext(ApiDataContext).options.gitRefName;
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -31,6 +31,7 @@ const DEFAULT_OPTIONS: Required<DocusaurusPluginTypeDocApiOptions> = {
 	debug: false,
 	disableVersioning: false,
 	exclude: [],
+	gitRefName: 'master',
 	id: DEFAULT_PLUGIN_ID,
 	includeCurrentVersion: true,
 	lastVersion: '',
@@ -61,7 +62,7 @@ export default function typedocApiPlugin(
 		...DEFAULT_OPTIONS,
 		...pluginOptions,
 	};
-	const { banner, breadcrumbs, id: pluginId, minimal, projectRoot, readmes } = options;
+	const { banner, breadcrumbs, id: pluginId, gitRefName, minimal, projectRoot, readmes } = options;
 	const isDefaultPluginId = pluginId === DEFAULT_PLUGIN_ID;
 	const versionsMetadata = readVersionsMetadata(context, options);
 	const versionsDocsDir = getVersionedDocsDirPath(context.siteDir, pluginId);
@@ -248,6 +249,7 @@ export default function typedocApiPlugin(
 					const optionsContextData: ApiOptions = {
 						banner,
 						breadcrumbs,
+						gitRefName,
 						minimal,
 						pluginId,
 						scopes: options.removeScopes,

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -77,7 +77,6 @@ export interface VersionMetadata {
 	versionPath: string; // /baseUrl/api/1.0.0
 	versionBadge: boolean;
 	versionBanner: VersionBanner | null;
-	versionGitRefName: string; // master
 	versionClassName: string;
 	isLast: boolean;
 	routePriority: number | undefined; // -1 for the latest

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -10,6 +10,7 @@ export type { VersionBanner };
 export interface DocusaurusPluginTypeDocApiOptions extends VersionsOptions {
 	banner?: string;
 	breadcrumbs?: boolean;
+	gitRefName?: string;
 	debug?: boolean;
 	exclude?: string[];
 	id?: string;
@@ -76,6 +77,7 @@ export interface VersionMetadata {
 	versionPath: string; // /baseUrl/api/1.0.0
 	versionBadge: boolean;
 	versionBanner: VersionBanner | null;
+	versionGitRefName: string; // master
 	versionClassName: string;
 	isLast: boolean;
 	routePriority: number | undefined; // -1 for the latest
@@ -98,6 +100,7 @@ export type SidebarItem = PropSidebarItem;
 export interface ApiOptions {
 	banner: string;
 	breadcrumbs: boolean;
+	gitRefName: string;
 	minimal: boolean;
 	pluginId: string;
 	scopes: string[];

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -61,6 +61,7 @@ const polyrepoMultiple = {
 // LOCAL DEV
 const local = {
 	projectRoot: path.join(__dirname, '../../boost'),
+	gitRefName: 'master',
 	packages: [
 		...[
 			'args',


### PR DESCRIPTION
This PR adds support for configurable git branch / ref names in `SourceLink` components, e.g. `master`, `main`, `v2.0.0`, etc.

I've decided to abandon the idea of using `globalData` since that seemed like overkill and instead followed the same pattern `useMinimalLayout` hook uses.

I've called the parameter `gitRefName` rather than `branchName`, since the ref might as well be a tag or a specific commit sha; From what I've observed, GitHub API accepts and ref name in the URL, for example:
- branch name - `main` - `https://github.com/serenity-js/serenity-js/blob/main/packages/core/src/events/DomainEvent.ts`
- tag name - `v3.0.0-rc.16` - `https://github.com/serenity-js/serenity-js/blob/v3.0.0-rc.16/packages/core/src/events/DomainEvent.ts`
- commit sha - `https://github.com/serenity-js/serenity-js/blob/636519a30032f1ff9a3fcba8c45433ca0e17fc7f/packages/core/src/events/DomainEvent.ts`

Please let me know if you'd like to see if any additional changes are needed.

Thanks!