### PR TITLE
new: Add changelogs support.

### DIFF
--- a/fixtures/polyrepo-standard/CHANGELOG.md
+++ b/fixtures/polyrepo-standard/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 1.2.3 - 2019-01-01
+
+#### 🚀 Updates
+
+- **[Button]** Add new Button component ([a1b2c3d][fake-commit])
+- **[Modal,Tooltip]** Refactor accessibility support ([a1b2c3d][fake-commit])
+
+#### 🐞 Fixes
+
+- **[auth]** Fixed a bug with the authentication flow ([a1b2c3d][fake-commit])
+
+#### 🛠 Internals
+
+- Add DangerJS to pipeline ([a1b2c3d][fake-commit])
+- Add missing tests for a handful of files ([a1b2c3d][fake-commit])
+
+[fake-commit]: #example

--- a/fixtures/polyrepo-standard/README.md
+++ b/fixtures/polyrepo-standard/README.md
@@ -1,0 +1,3 @@
+# polyrepo-standard
+
+This is a readme!

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -81,9 +81,14 @@ The following options are available to the plugin:
 - `packages` (`(string | PackageConfig)[]`) - List of packages relative to the project root.
   _(Required)_
 - `banner` (`string`) - Banner message to display at the top of the index page. Supports HTML.
+- `changelogName` (`string`) - Name of the changelog file within a package. Defaults to
+  `CHANGELOG.md`.
+- `changelogs` (`boolean`) - Include and render the changelog file from every package. Defaults to
+  `false`.
 - `exclude` (`string[]`) - List of glob patterns to exclude unwanted packages. This is necessary
   when using TypeScript project references.
-- `gitRefName` (`string`) - GitHub repository ref name to point the API links to. Defaults to `master`.
+- `gitRefName` (`string`) - GitHub repository ref name to point the API links to. Defaults to
+  `master`.
 - `minimal` (`boolean`) - Render a minimal layout and reduce the amount of information displayed.
   Defaults to `false`.
 - `packageJsonName` (`string`) - Name of the `package.json file`. Defaults to `package.json`.

--- a/packages/plugin/src/components/ApiChangelog.tsx
+++ b/packages/plugin/src/components/ApiChangelog.tsx
@@ -20,11 +20,9 @@ export default function ApiChangelog({
 			toc={Changelog.toc}
 			versionMetadata={versionMetadata}
 		>
-			{Changelog && (
-				<section className="tsd-readme">
-					<Changelog />
-				</section>
-			)}
+			<section className="tsd-readme">
+				<Changelog />
+			</section>
 		</ApiItemLayout>
 	);
 }

--- a/packages/plugin/src/components/ApiChangelog.tsx
+++ b/packages/plugin/src/components/ApiChangelog.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { PageMetadata } from '@docusaurus/theme-common';
+import type { Props as DocItemProps } from '@theme/DocItem';
+import ApiItemLayout from './ApiItemLayout';
+
+export interface ApiChangelogProps extends Pick<DocItemProps, 'route' | 'versionMetadata'> {
+	changelog: DocItemProps['content'];
+}
+
+export default function ApiChangelog({
+	changelog: Changelog,
+	route,
+	versionMetadata,
+}: ApiChangelogProps) {
+	return (
+		<ApiItemLayout
+			heading="Changelog"
+			pageMetadata={<PageMetadata description={Changelog.contentTitle} title="Changelog | API" />}
+			route={route}
+			toc={Changelog.toc}
+			versionMetadata={versionMetadata}
+		>
+			{Changelog && (
+				<section className="tsd-readme">
+					<Changelog />
+				</section>
+			)}
+		</ApiItemLayout>
+	);
+}

--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -1,28 +1,16 @@
-// This file is based on `DocItem` upstream, but since we aren't using markdown,
-// we had to duplicate it. Keep this file in sync as much as possible!
-// https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
-
 import React, { useMemo } from 'react';
 import type { JSONOutput } from 'typedoc';
-import { PageMetadata, ThemeClassNames, useWindowSize } from '@docusaurus/theme-common';
+import { PageMetadata } from '@docusaurus/theme-common';
 import type { TOCItem } from '@docusaurus/types';
-import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import type { Props as DocItemProps } from '@theme/DocItem';
-import DocPaginator from '@theme/DocPaginator';
-import DocVersionBadge from '@theme/DocVersionBadge';
-import Heading from '@theme/Heading';
-import TOC from '@theme/TOC';
-import TOCCollapsible from '@theme/TOCCollapsible';
-import { useBreadcrumbs } from '../hooks/useBreadcrumbs';
 import { useReflection } from '../hooks/useReflection';
 import { useReflectionMap } from '../hooks/useReflectionMap';
 import type { DeclarationReflectionMap } from '../types';
 import { getKindIconHtml } from '../utils/icons';
+import ApiItemLayout from './ApiItemLayout';
 import { Flags } from './Flags';
-import { Footer } from './Footer';
 import { Reflection } from './Reflection';
 import { TypeParametersGeneric } from './TypeParametersGeneric';
-import { VersionBanner } from './VersionBanner';
 
 function extractTOC(
 	item: JSONOutput.DeclarationReflection,
@@ -64,18 +52,12 @@ export interface ApiItemProps extends Pick<DocItemProps, 'route' | 'versionMetad
 
 export default function ApiItem({ readme: Readme, route, versionMetadata }: ApiItemProps) {
 	const item = useReflection((route as unknown as { id: number }).id)!;
-	const prevItem = useReflection(item.previousId);
-	const nextItem = useReflection(item.nextId);
 	const reflections = useReflectionMap();
-	const windowSize = useWindowSize();
-	const breadcrumbs = useBreadcrumbs();
-
-	// Table of contents
 	const toc = useMemo(() => extractTOC(item, reflections), [item, reflections]);
-	const canRenderTOC = toc.length > 0;
-	const renderTocDesktop = canRenderTOC && (windowSize === 'desktop' || windowSize === 'ssr');
 
 	// Pagination
+	const prevItem = useReflection(item.previousId);
+	const nextItem = useReflection(item.nextId);
 	const pagingMetadata = useMemo(
 		() => ({
 			next: nextItem
@@ -95,68 +77,33 @@ export default function ApiItem({ readme: Readme, route, versionMetadata }: ApiI
 	);
 
 	return (
-		<>
-			<PageMetadata
-				description={item.comment?.shortText ?? item.comment?.text}
-				title={`${item.name} | API`}
-			/>
+		<ApiItemLayout
+			heading={
+				<>
+					<span className="tsd-header-flags">
+						<Flags flags={item.flags} />
+					</span>
+					{item.name} <TypeParametersGeneric params={item.typeParameter} />
+				</>
+			}
+			pageMetadata={
+				<PageMetadata
+					description={item.comment?.shortText ?? item.comment?.text}
+					title={`${item.name} | API`}
+				/>
+			}
+			pagingMetadata={pagingMetadata}
+			route={route}
+			toc={toc}
+			versionMetadata={versionMetadata}
+		>
+			{Readme && (
+				<section className="tsd-readme">
+					<Readme />
+				</section>
+			)}
 
-			<div className="row">
-				<div className="col apiItemCol">
-					<VersionBanner versionMetadata={versionMetadata} />
-
-					<div className="apiItemContainer">
-						<article>
-							{breadcrumbs && <DocBreadcrumbs />}
-
-							<DocVersionBadge />
-
-							{canRenderTOC && (
-								<TOCCollapsible
-									className={`${ThemeClassNames.docs.docTocMobile ?? ''} apiTocMobile`}
-									maxHeadingLevel={6}
-									minHeadingLevel={1}
-									toc={toc}
-								/>
-							)}
-
-							<div className={`${ThemeClassNames.docs.docMarkdown ?? ''} markdown`}>
-								<header>
-									<Heading as="h1">
-										<span className="tsd-header-flags">
-											<Flags flags={item.flags} />
-										</span>
-										{item.name} <TypeParametersGeneric params={item.typeParameter} />
-									</Heading>
-								</header>
-
-								{Readme && (
-									<section className="tsd-readme">
-										<Readme />
-									</section>
-								)}
-
-								<Reflection reflection={item} />
-							</div>
-
-							<Footer />
-						</article>
-
-						<DocPaginator {...pagingMetadata} />
-					</div>
-				</div>
-
-				{renderTocDesktop && (
-					<div className="col col--3">
-						<TOC
-							className={ThemeClassNames.docs.docTocDesktop}
-							maxHeadingLevel={6}
-							minHeadingLevel={1}
-							toc={toc}
-						/>
-					</div>
-				)}
-			</div>
-		</>
+			<Reflection reflection={item} />
+		</ApiItemLayout>
 	);
 }

--- a/packages/plugin/src/components/ApiItemLayout.tsx
+++ b/packages/plugin/src/components/ApiItemLayout.tsx
@@ -1,0 +1,94 @@
+// This file is based on `DocItem` upstream, but since we aren't using markdown,
+// we had to duplicate it. Keep this file in sync as much as possible!
+// https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/DocItem/index.tsx
+
+import React from 'react';
+import type { PropNavigation } from '@docusaurus/plugin-content-docs';
+import { ThemeClassNames, useWindowSize } from '@docusaurus/theme-common';
+import type { TOCItem } from '@docusaurus/types';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import type { Props as DocItemProps } from '@theme/DocItem';
+import DocPaginator from '@theme/DocPaginator';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import Heading from '@theme/Heading';
+import TOC from '@theme/TOC';
+import TOCCollapsible from '@theme/TOCCollapsible';
+import { useBreadcrumbs } from '../hooks/useBreadcrumbs';
+import { Footer } from './Footer';
+import { VersionBanner } from './VersionBanner';
+
+export interface ApiItemLayoutProps extends Pick<DocItemProps, 'route' | 'versionMetadata'> {
+	children: React.ReactNode;
+	heading: React.ReactNode;
+	toc: readonly TOCItem[];
+	pageMetadata?: React.ReactNode;
+	pagingMetadata?: PropNavigation;
+}
+
+export default function ApiItemLayout({
+	children,
+	heading,
+	pageMetadata,
+	pagingMetadata,
+	toc,
+	versionMetadata,
+}: ApiItemLayoutProps) {
+	const windowSize = useWindowSize();
+	const breadcrumbs = useBreadcrumbs();
+
+	// Table of contents
+	const canRenderTOC = toc.length > 0;
+	const renderTocDesktop = canRenderTOC && (windowSize === 'desktop' || windowSize === 'ssr');
+
+	return (
+		<>
+			{pageMetadata}
+
+			<div className="row">
+				<div className="col apiItemCol">
+					<VersionBanner versionMetadata={versionMetadata} />
+
+					<div className="apiItemContainer">
+						<article>
+							{breadcrumbs && <DocBreadcrumbs />}
+
+							<DocVersionBadge />
+
+							{canRenderTOC && (
+								<TOCCollapsible
+									className={`${ThemeClassNames.docs.docTocMobile ?? ''} apiTocMobile`}
+									maxHeadingLevel={6}
+									minHeadingLevel={1}
+									toc={toc}
+								/>
+							)}
+
+							<div className={`${ThemeClassNames.docs.docMarkdown ?? ''} markdown`}>
+								<header>
+									<Heading as="h1">{heading}</Heading>
+								</header>
+
+								{children}
+							</div>
+
+							<Footer />
+						</article>
+
+						{pagingMetadata && <DocPaginator {...pagingMetadata} />}
+					</div>
+				</div>
+
+				{renderTocDesktop && (
+					<div className="col col--3">
+						<TOC
+							className={ThemeClassNames.docs.docTocDesktop}
+							maxHeadingLevel={6}
+							minHeadingLevel={1}
+							toc={toc}
+						/>
+					</div>
+				)}
+			</div>
+		</>
+	);
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -277,8 +277,8 @@ export default function typedocApiPlugin(
 							path: info.permalink,
 							exact: true,
 							component: path.join(__dirname, './components/ApiItem.js'),
-							sidebar: 'api',
 							modules,
+							sidebar: 'api',
 							// Map the ID here instead of creating a JSON data file,
 							// otherwise this will create thousands of files!
 							id: info.id,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -355,8 +355,6 @@ export default function typedocApiPlugin(
 			// otherwise we collide with the native docs/blog plugins.
 			const include = packageConfigs.map((cfg) => path.join(options.projectRoot, cfg.packagePath));
 
-			console.log(include);
-
 			return {
 				module: {
 					rules: [

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -73,6 +73,7 @@ export default function typedocApiPlugin(
 		minimal,
 		projectRoot,
 		readmes,
+		removeScopes,
 	} = options;
 	const isDefaultPluginId = pluginId === DEFAULT_PLUGIN_ID;
 	const versionsMetadata = readVersionsMetadata(context, options);
@@ -205,7 +206,7 @@ export default function typedocApiPlugin(
 						return {
 							...metadata,
 							packages,
-							sidebars: await extractSidebar(packages, options.removeScopes, changelogs),
+							sidebars: await extractSidebar(packages, removeScopes, changelogs),
 						};
 					}),
 				),
@@ -264,7 +265,7 @@ export default function typedocApiPlugin(
 						gitRefName,
 						minimal,
 						pluginId,
-						scopes: options.removeScopes,
+						scopes: removeScopes,
 					};
 					const optionsData = await createData('options.json', JSON.stringify(optionsContextData));
 

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -101,10 +101,11 @@ export function createReflectionMap(
 	return map;
 }
 
-export function loadPackageJsonAndReadme(
+export function loadPackageJsonAndDocs(
 	initialDir: string,
 	pkgFileName: string = 'package.json',
 	readmeFileName: string = 'README.md',
+	changelogFileName: string = 'CHANGELOG.md',
 ) {
 	let currentDir = initialDir;
 
@@ -113,6 +114,7 @@ export function loadPackageJsonAndReadme(
 	}
 
 	const readmePath = path.join(currentDir, readmeFileName);
+	const changelogPath = path.join(currentDir, changelogFileName);
 
 	return {
 		packageJson: JSON.parse(fs.readFileSync(path.join(currentDir, pkgFileName), 'utf8')) as {
@@ -120,6 +122,7 @@ export function loadPackageJsonAndReadme(
 			version: string;
 		},
 		readmePath: fs.existsSync(readmePath) ? readmePath : '',
+		changelogPath: fs.existsSync(changelogPath) ? changelogPath : '',
 	};
 }
 
@@ -297,10 +300,11 @@ export function flattenAndGroupPackages(
 
 				// We have a matching entry point, so store the record
 				if (!packages[cfg.packagePath]) {
-					const { packageJson, readmePath } = loadPackageJsonAndReadme(
+					const { packageJson, readmePath, changelogPath } = loadPackageJsonAndDocs(
 						path.join(options.projectRoot, cfg.packagePath),
 						options.packageJsonName,
 						options.readmeName,
+						options.changelogName,
 					);
 
 					packages[cfg.packagePath] = {
@@ -308,6 +312,7 @@ export function flattenAndGroupPackages(
 						packageName: (versioned && cfg.packageName) || packageJson.name,
 						packageVersion: (versioned && cfg.packageVersion) || packageJson.version,
 						readmePath,
+						changelogPath,
 					};
 
 					// eslint-disable-next-line no-param-reassign
@@ -362,5 +367,5 @@ export function flattenAndGroupPackages(
 }
 
 export function formatPackagesWithoutHostInfo(packages: PackageReflectionGroup[]) {
-	return packages.map(({ readmePath, ...pkg }) => pkg);
+	return packages.map(({ changelogPath, readmePath, ...pkg }) => pkg);
 }

--- a/packages/plugin/src/plugin/sidebar.ts
+++ b/packages/plugin/src/plugin/sidebar.ts
@@ -1,4 +1,5 @@
 import { JSONOutput } from 'typedoc';
+import { normalizeUrl } from '@docusaurus/utils';
 import { DeclarationReflectionMap, PackageReflectionGroup, SidebarItem } from '../types';
 import { removeScopes } from '../utils/links';
 import { createReflectionMap } from './data';
@@ -66,6 +67,7 @@ export function extractReflectionSidebar(pkg: JSONOutput.ProjectReflection): Sid
 export function extractSidebar(
 	packages: PackageReflectionGroup[],
 	scopes: string[],
+	changelogs: boolean,
 ): SidebarItem[] {
 	if (packages.length === 0) {
 		return [];
@@ -91,9 +93,17 @@ export function extractSidebar(
 		});
 
 		// Always include the overview as the 1st item
+		const indexHref = pkg.entryPoints.find((entry) => entry.index)?.reflection.permalink ?? '';
+
 		subItems.unshift({
-			href: pkg.entryPoints.find((entry) => entry.index)?.reflection.permalink ?? '',
+			href: indexHref,
 			label: 'Overview',
+			type: 'link',
+		});
+
+		subItems.push({
+			href: normalizeUrl([indexHref, 'changelog']),
+			label: 'Changelog',
 			type: 'link',
 		});
 

--- a/packages/plugin/src/plugin/sidebar.ts
+++ b/packages/plugin/src/plugin/sidebar.ts
@@ -101,11 +101,13 @@ export function extractSidebar(
 			type: 'link',
 		});
 
-		subItems.push({
-			href: normalizeUrl([indexHref, 'changelog']),
-			label: 'Changelog',
-			type: 'link',
-		});
+		if (changelogs) {
+			subItems.push({
+				href: normalizeUrl([indexHref, 'changelog']),
+				label: 'Changelog',
+				type: 'link',
+			});
+		}
 
 		return {
 			collapsed: true,

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -10,6 +10,8 @@ export type { VersionBanner };
 export interface DocusaurusPluginTypeDocApiOptions extends VersionsOptions {
 	banner?: string;
 	breadcrumbs?: boolean;
+	changelogName?: string;
+	changelogs?: boolean;
 	gitRefName?: string;
 	debug?: boolean;
 	exclude?: string[];
@@ -118,6 +120,7 @@ export interface PackageReflectionGroup {
 	entryPoints: PackageReflectionGroupEntry[];
 	packageName: string;
 	packageVersion: string;
+	changelogPath: string;
 	readmePath?: string;
 }
 

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -120,7 +120,7 @@ export interface PackageReflectionGroup {
 	entryPoints: PackageReflectionGroupEntry[];
 	packageName: string;
 	packageVersion: string;
-	changelogPath: string;
+	changelogPath?: string;
 	readmePath?: string;
 }
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -249,8 +249,8 @@ module.exports = {
 			{
 				exclude: ['**/themes/*', '**/website/*'],
 				minimal: false,
-				readmes: true,
-				changelogs: true,
+				readmes: false,
+				changelogs: false,
 				// removeScopes: ['boost'],
 				...getPluginConfig(),
 			},

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -249,7 +249,8 @@ module.exports = {
 			{
 				exclude: ['**/themes/*', '**/website/*'],
 				minimal: false,
-				readmes: false,
+				readmes: true,
+				changelogs: true,
 				// removeScopes: ['boost'],
 				...getPluginConfig(),
 			},


### PR DESCRIPTION
Generates a `/api/<package>/changelog` route and renders a `CHANGELOG.md` file in a similar fashion to the readme.