### PR TITLE
fix #48

### DIFF
--- a/packages/plugin/src/plugin/sidebar.ts
+++ b/packages/plugin/src/plugin/sidebar.ts
@@ -9,15 +9,21 @@ export function groupSidebarItems(
 	groups: JSONOutput.ReflectionGroup[],
 ): SidebarItem[] {
 	const items: SidebarItem[] = [];
-	const sortedGroups = groups.sort((a, b) => a.title.localeCompare(b.title));
+
+	const categories = groups.flatMap(group => {
+		// Prefer @category annotation over built-in grouping
+		return group.categories || group
+	});
+
+	const sortedCategories = categories.sort((a, b) =>  a.title.localeCompare(b.title));
 
 	function getLastItemInGroup(index: number) {
-		const length = sortedGroups[index]?.children?.length;
+		const length = sortedCategories[index]?.children?.length;
 
-		return length ? sortedGroups[index]?.children?.[length - 1] : undefined;
+		return length ? sortedCategories[index]?.children?.[length - 1] : undefined;
 	}
 
-	sortedGroups.forEach((group, groupIndex) => {
+	sortedCategories.forEach((group, groupIndex) => {
 		const { children } = group;
 
 		if (!children || children.length === 0) {


### PR DESCRIPTION
This PR allows code to be annotated with `@category` and have it reflected properly in both the index but also the sidebar. This especially useful when you want to talk about API items in the context of specific frameworks.