### PR TITLE
fix: Fix comments `@returns` rendering.

### DIFF
--- a/fixtures/monorepo/standard/src/index.ts
+++ b/fixtures/monorepo/standard/src/index.ts
@@ -1,1 +1,10 @@
 export type Type = 'standard';
+
+/**
+ * a thing for a thing
+ * @param a id
+ * @returns returns the param
+ */
+export function bizz(a: string): string {
+  return a;
+}

--- a/packages/plugin/src/components/MemberSignatureBody.tsx
+++ b/packages/plugin/src/components/MemberSignatureBody.tsx
@@ -34,6 +34,30 @@ export interface MemberSignatureBodyProps {
 	sig: JSONOutput.SignatureReflection;
 }
 
+function excludeBlockTags(comment?: JSONOutput.Comment):  JSONOutput.Comment | undefined {
+	if (comment) {
+		const { blockTags, ...rest } = comment;
+		return rest;
+ 	}
+	return undefined;
+}
+
+function intoReturnComment(comment?: JSONOutput.Comment): JSONOutput.Comment | undefined {
+	if (comment?.blockTags) {
+		const tags = comment.blockTags.map((tag) => tag.tag);
+
+		if (tags.includes('@returns')) {
+			const index = tags.indexOf('@returns');
+
+			return {
+				summary: comment.blockTags[index].content
+			}
+		}
+	}
+
+	return undefined;
+}
+
 // eslint-disable-next-line complexity
 export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyProps) {
 	const minimal = useMinimalLayout();
@@ -45,7 +69,7 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 		<>
 			{!hideSources && <MemberSources reflection={sig} />}
 
-			<Comment comment={sig.comment} />
+			<Comment comment={excludeBlockTags(sig.comment)} />
 
 			{hasComment(sig.comment) && (showTypes || showParams || showReturn) && (
 				<hr className="tsd-divider" />
@@ -86,7 +110,7 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 						Returns <Type type={sig.type} />
 					</h4>
 
-					<Comment comment={sig.comment} />
+					<Comment comment={intoReturnComment(sig.comment)} />
 
 					<Parameter param={sig.type?.declaration} />
 				</>


### PR DESCRIPTION
Prior to this, @returns would be emitted literally and it was duplicated. This
PR, subsets the comment objects so that comments for the return type render
properly

Before:
<img width="1170" alt="Screen Shot 2022-07-12 at 10 55 16 AM" src="https://user-images.githubusercontent.com/183799/178521062-66fc4a31-b4e6-4185-aee8-788a059add40.png">

After:
<img width="1098" alt="Screen Shot 2022-07-12 at 10 56 02 AM" src="https://user-images.githubusercontent.com/183799/178521109-8345a20a-6e8b-4e4e-ab98-a76c3baaf4b5.png">

