### PR TITLE
new: alpha beta experimental modifiers

### DIFF
--- a/fixtures/monorepo/standard/src/index.ts
+++ b/fixtures/monorepo/standard/src/index.ts
@@ -4,7 +4,26 @@ export type Type = 'standard';
  * a thing for a thing
  * @param a id
  * @returns returns the param
+ * @beta
  */
 export function bizz(a: string): string {
-  return a;
+	return a;
+}
+
+/**
+ * thing for a thing
+ * @beta
+ */
+export interface Foo {
+	/**
+	 * very experimental
+	 * @alpha
+	 */
+	foo: string;
+
+	/**
+	 * very experimental
+	 * @experimental
+	 */
+	a: string;
 }

--- a/fixtures/monorepo/standard/src/index.ts
+++ b/fixtures/monorepo/standard/src/index.ts
@@ -1,4 +1,25 @@
+/**
+ * a type
+ * @beta
+ */
 export type Type = 'standard';
+
+/**
+ * newy new guy
+ * @param a a thing
+ * @param b b thing
+ * @alpha
+ */
+export function bizz(a: string, b: string): string;
+
+/**
+ * newy new guy
+ * @param a a thing
+ * @param b b thing
+ * @param c c thing
+ * @beta
+ */
+export function bizz(a: string, b: string, c: string): string;
 
 /**
  * a thing for a thing
@@ -6,8 +27,8 @@ export type Type = 'standard';
  * @returns returns the param
  * @beta
  */
-export function bizz(a: string): string {
-	return a;
+export function bizz(...args: string[]): string {
+	return args[0];
 }
 
 /**

--- a/packages/plugin/src/components/Comment.tsx
+++ b/packages/plugin/src/components/Comment.tsx
@@ -24,6 +24,18 @@ export function displayPartsToMarkdown(parts: JSONOutput.CommentDisplayPart[]): 
 	return parts.map((part) => part.text).join('');
 }
 
+function getModifierClassName(tag: string) {
+	switch (tag) {
+		case '@beta':
+		case '@experimental':
+			return 'warning';
+		case '@alpha':
+			return 'danger';
+		default:
+			return 'info';
+	}
+}
+
 export function Comment({ comment, root }: CommentProps) {
 	if (!comment || !hasComment(comment)) {
 		return null;
@@ -31,6 +43,16 @@ export function Comment({ comment, root }: CommentProps) {
 
 	return (
 		<div className={`tsd-comment tsd-typography ${root ? 'tsd-comment-root' : ''}`}>
+			{comment.modifierTags && comment.modifierTags.length > 0 && (
+				<div className="badge-group">
+					{comment.modifierTags.map((tag) => (
+						<span key={tag} className={`badge badge--${getModifierClassName(tag)}`}>
+							{tag.slice(1)}
+						</span>
+					))}
+				</div>
+			)}
+
 			{!!comment.summary && (
 				<div className="lead">
 					<Markdown content={displayPartsToMarkdown(comment.summary)} />

--- a/packages/plugin/src/components/Comment.tsx
+++ b/packages/plugin/src/components/Comment.tsx
@@ -24,18 +24,6 @@ export function displayPartsToMarkdown(parts: JSONOutput.CommentDisplayPart[]): 
 	return parts.map((part) => part.text).join('');
 }
 
-function getModifierClassName(tag: string) {
-	switch (tag) {
-		case '@beta':
-		case '@experimental':
-			return 'warning';
-		case '@alpha':
-			return 'danger';
-		default:
-			return 'info';
-	}
-}
-
 export function Comment({ comment, root }: CommentProps) {
 	if (!comment || !hasComment(comment)) {
 		return null;
@@ -43,16 +31,6 @@ export function Comment({ comment, root }: CommentProps) {
 
 	return (
 		<div className={`tsd-comment tsd-typography ${root ? 'tsd-comment-root' : ''}`}>
-			{comment.modifierTags && comment.modifierTags.length > 0 && (
-				<div className="badge-group">
-					{comment.modifierTags.map((tag) => (
-						<span key={tag} className={`badge badge--${getModifierClassName(tag)}`}>
-							{tag.slice(1)}
-						</span>
-					))}
-				</div>
-			)}
-
 			{!!comment.summary && (
 				<div className="lead">
 					<Markdown content={displayPartsToMarkdown(comment.summary)} />

--- a/packages/plugin/src/components/CommentBadges.tsx
+++ b/packages/plugin/src/components/CommentBadges.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { JSONOutput } from 'typedoc';
+
+function getModifierClassName(tag: string) {
+	switch (tag) {
+		case '@beta':
+		case '@experimental':
+			return 'warning';
+		case '@alpha':
+			return 'danger';
+		default:
+			return 'info';
+	}
+}
+
+export type CommentWithModifiers = Pick<JSONOutput.Comment, 'blockTags' | 'summary'> &
+	Required<Pick<JSONOutput.Comment, 'modifierTags'>>;
+
+export function isCommentWithModifiers(
+	comment?: JSONOutput.Comment,
+): comment is CommentWithModifiers {
+	return !!comment && !!comment.modifierTags && comment.modifierTags.length > 0;
+}
+
+interface CommentBadgesProps {
+	comment: CommentWithModifiers;
+}
+
+export function CommentBadges({ comment }: CommentBadgesProps) {
+	const { modifierTags } = comment;
+	return (
+		<div className="badge-group">
+			{modifierTags.map((tag) => (
+				<span key={tag} className={`badge badge--${getModifierClassName(tag)}`}>
+					{tag.slice(1)}
+				</span>
+			))}
+		</div>
+	);
+}

--- a/packages/plugin/src/components/Member.tsx
+++ b/packages/plugin/src/components/Member.tsx
@@ -6,6 +6,7 @@ import { useReflection } from '../hooks/useReflection';
 import { useReflectionMap } from '../hooks/useReflectionMap';
 import { hasOwnDocument } from '../utils/visibility';
 import { AnchorLink } from './AnchorLink';
+import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Flags } from './Flags';
 import { MemberDeclaration } from './MemberDeclaration';
 import { MemberGetterSetter } from './MemberGetterSetter';
@@ -20,7 +21,7 @@ export interface MemberProps {
 export function Member({ id }: MemberProps) {
 	const reflections = useReflectionMap();
 	const reflection = useReflection(id)!;
-
+	const { comment } = reflection;
 	let content: React.ReactNode = null;
 
 	if (reflection.signatures) {
@@ -46,6 +47,7 @@ export function Member({ id }: MemberProps) {
 				<SourceLink sources={reflection.sources} />
 				<Flags flags={reflection.flags} />
 				{reflection.name}
+				{isCommentWithModifiers(comment) && <CommentBadges comment={comment} />}
 			</h3>
 
 			{content}

--- a/packages/plugin/src/components/MemberSignatureBody.tsx
+++ b/packages/plugin/src/components/MemberSignatureBody.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { JSONOutput } from 'typedoc';
 import { useMinimalLayout } from '../hooks/useMinimalLayout';
 import { Comment, hasComment } from './Comment';
+import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { DefaultValue } from './DefaultValue';
 import { Flags } from './Flags';
 import { hasSources, MemberSources } from './MemberSources';
@@ -34,11 +35,11 @@ export interface MemberSignatureBodyProps {
 	sig: JSONOutput.SignatureReflection;
 }
 
-function excludeBlockTags(comment?: JSONOutput.Comment):  JSONOutput.Comment | undefined {
+function excludeBlockTags(comment?: JSONOutput.Comment): JSONOutput.Comment | undefined {
 	if (comment) {
 		const { blockTags, ...rest } = comment;
 		return rest;
- 	}
+	}
 	return undefined;
 }
 
@@ -50,8 +51,8 @@ function intoReturnComment(comment?: JSONOutput.Comment): JSONOutput.Comment | u
 			const index = tags.indexOf('@returns');
 
 			return {
-				summary: comment.blockTags[index].content
-			}
+				summary: comment.blockTags[index].content,
+			};
 		}
 	}
 
@@ -68,6 +69,8 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 	return (
 		<>
 			{!hideSources && <MemberSources reflection={sig} />}
+
+			{isCommentWithModifiers(sig.comment) && <CommentBadges comment={sig.comment} />}
 
 			<Comment comment={excludeBlockTags(sig.comment)} />
 

--- a/packages/plugin/src/components/Reflection.tsx
+++ b/packages/plugin/src/components/Reflection.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import type { JSONOutput } from 'typedoc';
 import { createHierarchy } from '../utils/hierarchy';
 import { Comment, hasComment } from './Comment';
+import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Hierarchy } from './Hierarchy';
 import { Icon } from './Icon';
 import { Index } from './Index';
@@ -19,13 +20,13 @@ export interface ReflectionProps {
 		| JSONOutput.Reflection
 		| JSONOutput.SignatureReflection;
 }
-
 // eslint-disable-next-line complexity
 export function Reflection({ reflection }: ReflectionProps) {
 	const hierarchy = useMemo(() => createHierarchy(reflection), [reflection]);
 
 	return (
 		<>
+			{isCommentWithModifiers(reflection.comment) && <CommentBadges comment={reflection.comment} />}
 			{hasComment(reflection.comment) && <Comment root comment={reflection.comment} />}
 
 			{'typeParameter' in reflection &&

--- a/packages/plugin/src/components/styles.css
+++ b/packages/plugin/src/components/styles.css
@@ -204,6 +204,18 @@ html[data-theme='light'] .tsd-panel-content {
 	vertical-align: middle;
 }
 
+/* MODIFIERS */
+
+.badge-group {
+	display: flex;
+	margin-bottom: 1rem;
+}
+
+.badge-group > span {
+	margin-right: 0.5rem;
+}
+
+
 /* SYNTAX */
 
 .tsd-generics {

--- a/packages/plugin/src/components/styles.css
+++ b/packages/plugin/src/components/styles.css
@@ -207,12 +207,17 @@ html[data-theme='light'] .tsd-panel-content {
 /* MODIFIERS */
 
 .badge-group {
-	display: flex;
-	margin-bottom: 1rem;
+	font-size: var(--tsd-font-small);
+	vertical-align: middle;
+}
+
+.tsd-panel-header .badge-group {
+	display: inline-block;
+	margin-left: .25em;
 }
 
 .badge-group > span {
-	margin-right: 0.5rem;
+	margin-right: 0.25rem;
 }
 
 


### PR DESCRIPTION
This adds badges to entities that are marked with stabilitity modifiers. I'm open to
suggestions on better ways of rendering this information.

![Screen Shot 2022-07-15 at 1 04 14 PM](https://user-images.githubusercontent.com/183799/179273733-59ccb464-824c-4b2a-9286-beb567c00c14.png)
![Screen Shot 2022-07-15 at 1 03 39 PM](https://user-images.githubusercontent.com/183799/179273736-9ac58d1d-3f39-412c-9bac-a9ee5dc0d959.png)

