### PR TITLE
deps(typedoc): Update to v0.23.8

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -51,7 +51,7 @@
     "@docusaurus/utils": "2.0.0-beta.22",
     "@vscode/codicons": "^0.0.31",
     "marked": "^3.0.8",
-    "typedoc": "^0.23.7"
+    "typedoc": "^0.23.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-beta.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8496,7 +8496,7 @@ __metadata:
     marked: ^3.0.8
     react: ^17.0.2
     react-dom: ^17.0.2
-    typedoc: ^0.23.7
+    typedoc: ^0.23.8
     typescript: ^4.7.4
   peerDependencies:
     react: ">=16.0.0"
@@ -17998,9 +17998,9 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"typedoc@npm:^0.23.7":
-  version: 0.23.7
-  resolution: "typedoc@npm:0.23.7"
+"typedoc@npm:^0.23.8":
+  version: 0.23.8
+  resolution: "typedoc@npm:0.23.8"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.0.16
@@ -18010,7 +18010,7 @@ resolve@^2.0.0-next.3:
     typescript: 4.6.x || 4.7.x
   bin:
     typedoc: bin/typedoc
-  checksum: 70e4462602a989c51657111db8689947d7ac0e938b2edee1045b279808c56a6ffd2d42ed0f8080645e28bc8c84f82cb3faec54ea5cc5b5fd62d2fc4ea4548297
+  checksum: 99568e5df15781def0761d9876a86883bb58cb5318c258be965628626cc33737cd605640de2a9397f6722bccaed70aeb1e68c5f390b03ac7e8a17da9f091f906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Includes fixes to typedoc that I upstreamed https://github.com/TypeStrong/typedoc/pull/2001