### PR TITLE
fix: Fix 'Duplicate routes found!' warning for polyrepos

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -320,17 +320,21 @@ export default function typedocApiPlugin(
 
 					const indexPermalink = normalizeUrl([loadedVersion.versionPath]);
 
-					routes.push({
-						path: indexPermalink,
-						exact: true,
-						component: path.join(__dirname, './components/ApiIndex.js'),
-						modules: {
-							options: optionsData,
-							packages: packagesData,
-							versionMetadata,
-						},
-						sidebar: 'api',
-					});
+					if (loadedVersion.packages.length > 1) {
+						// Only write out the ApiIndex only when we have multiple packages
+						// otherwise we will have 2 top-level entries in the route entries
+						routes.push({
+							path: indexPermalink,
+							exact: true,
+							component: path.join(__dirname, './components/ApiIndex.js'),
+							modules: {
+								options: optionsData,
+								packages: packagesData,
+								versionMetadata,
+							},
+							sidebar: 'api',
+						});
+					}
 
 					addRoute({
 						path: indexPermalink,


### PR DESCRIPTION
Fixes an issue if you're trying to run the plugin on a single repo 2 top level entries
would be inserted into the route config. This would manifest its self with the following
docusuaurus warning which was pretty confusing.

```
[WARNING] Duplicate routes found!
- Attempting to create page at /api, but a page already exists at this route.
This could lead to non-deterministic routing behavior.
```

You can reproduce this on master by running the following:

```sh
DOCS_REPO_TYPE=polyrepo yarn start
```
