### PR TITLE
fix: Configured TypeDoc to recognise `@apilink` and `@doclink` tags

### DIFF
--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -68,10 +68,7 @@ export async function generateJson(
 		excludeProtected: true,
 		// Enable verbose logging when debugging
 		logLevel: options.debug ? 'Verbose' : 'Info',
-		inlineTags: inlineTags.concat(
-                  '@doclink',
-                  '@apilink'
-                ),
+		inlineTags: [...inlineTags, '@apilink', '@doclink'] as `@${string}`[],
 		...options.typedocOptions,
 		// Control how config and packages are detected
 		tsconfig,

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import * as TypeDoc from 'typedoc';
 import { JSONOutput, ReflectionKind } from 'typedoc';
-import { inlineTags } from 'typedoc/dist/lib/utils/options/tsdoc-defaults';
 import ts from 'typescript';
 import { normalizeUrl } from '@docusaurus/utils';
 import {
@@ -68,7 +67,7 @@ export async function generateJson(
 		excludeProtected: true,
 		// Enable verbose logging when debugging
 		logLevel: options.debug ? 'Verbose' : 'Info',
-		inlineTags: [...inlineTags, '@apilink', '@doclink'] as `@${string}`[],
+		inlineTags: ['@link', '@inheritDoc', '@label', '@linkcode', '@linkplain', '@apilink', '@doclink'] as `@${string}`[],
 		...options.typedocOptions,
 		// Control how config and packages are detected
 		tsconfig,

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import * as TypeDoc from 'typedoc';
 import { JSONOutput, ReflectionKind } from 'typedoc';
+import { inlineTags } from 'typedoc/dist/lib/utils/options/tsdoc-defaults';
 import ts from 'typescript';
 import { normalizeUrl } from '@docusaurus/utils';
 import {
@@ -67,6 +68,10 @@ export async function generateJson(
 		excludeProtected: true,
 		// Enable verbose logging when debugging
 		logLevel: options.debug ? 'Verbose' : 'Info',
+		inlineTags: inlineTags.concat(
+                  '@doclink',
+                  '@apilink'
+                ),
 		...options.typedocOptions,
 		// Control how config and packages are detected
 		tsconfig,


### PR DESCRIPTION
TypeDoc has a list of [recognised `inlineTags`](https://github.com/TypeStrong/typedoc/blob/56517ef39b90d612c56110d25375cc824feaf5d6/src/lib/utils/options/tsdoc-defaults.ts#L31) and since `docusaurus-plugin-typedoc-api` tags `@apilink` and `@doclink` are not on the list - it emits a warning when they're encountered.

~Since `inlineTags` overwrites the defaults, this change proposes to load the TypeDoc defaults and add the custom tags when bootstrapping TypeDoc.~

TypeDoc doesn't export the list of default `inlineTags`, so the build has failed. Instead of importing the defaults, I've copied them from [TypeDoc](https://github.com/TypeStrong/typedoc/blob/56517ef39b90d612c56110d25375cc824feaf5d6/src/lib/utils/options/tsdoc-defaults.ts#L31).

This introduces a risk that `docusaurus-plugin-typedoc-api` will need to keep in sync with TypeDoc regarding `inlineLinks`. An alternative to that is to relax build rules so that they allow for deep imports.

Closes #64