### PR TITLE
docs: update badge on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # docusaurus-plugin-typedoc-api
 
-[![Build Status](https://travis-ci.org/milesj/docusaurus-plugin-typedoc-api.svg?branch=master)](https://travis-ci.org/milesj/docusaurus-plugin-typedoc-api)
+![Build](https://github.com/milesj/docusaurus-plugin-typedoc-api/actions/workflows/build.yml/badge.svg?branch=master)
 [![npm version](https://badge.fury.io/js/docusaurus-plugin-typedoc-api.svg)](https://www.npmjs.com/package/docusaurus-plugin-typedoc-api)
-[![npm deps](https://david-dm.org/milesj/docusaurus-plugin-typedoc-api.svg?path=packages/plugin)](https://www.npmjs.com/package/docusaurus-plugin-typedoc-api)
 
 A Docusaurus plugin for generating source code `/api/*` routes, powered by
 [TypeDoc](https://typedoc.org/).


### PR DESCRIPTION
- Update the `build status` badge based on the GitHub action build status per the master branch.
- Remove the `npm deps` badge because the parent project is dead. https://github.com/alanshaw/david/issues