### PR TITLE
Add remark and rehype plugins support

### DIFF
--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -103,6 +103,8 @@ The following options are available to the plugin:
   sidebar, excluding "Overview" and "Changelog". Defaults to alphabetical.
 - `tsconfigName` (`string`) - Name of the TypeScript config file in the project root. Defaults to
   `tsconfig.json`.
+- `remarkPlugins` (`MDXPlugin[]`) - List of remark plugins to use for [MDX compilation](https://mdxjs.com/docs/extending-mdx).
+- `rehypePlugins` (`MDXPlugin[]`) - List of rehype plugins to use for [MDX compilation](https://mdxjs.com/docs/extending-mdx).
 - `typedocOptions` (`object`) - [TypeDoc options](https://typedoc.org/guides/options/#input-options)
   to pass to the compiler. Only supports a small subset of options, primarily around visibility
   exclusion.

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -50,6 +50,8 @@ const DEFAULT_OPTIONS: Required<DocusaurusPluginTypeDocApiOptions> = {
 	routeBasePath: 'api',
 	tsconfigName: 'tsconfig.json',
 	typedocOptions: {},
+	remarkPlugins: [],
+	rehypePlugins: [],
 	versions: {},
 };
 
@@ -413,6 +415,8 @@ export default function typedocApiPlugin(
 									loader: require.resolve('@docusaurus/mdx-loader'),
 									options: {
 										admonitions: true,
+										remarkPlugins: options.remarkPlugins,
+										rehypePlugins: options.rehypePlugins,
 										staticDir: path.join(context.siteDir, 'static'),
 										// Since this isnt a doc/blog page, we can get
 										// away with it being a partial!

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -1,4 +1,5 @@
 import type { JSONOutput, TypeDocOptions } from 'typedoc';
+import type { MDXPlugin } from '@docusaurus/mdx-loader'
 import type {
 	PropSidebarItem,
 	VersionBanner,
@@ -28,6 +29,9 @@ export interface DocusaurusPluginTypeDocApiOptions
 	sortSidebar?: (a: string, d: string) => number;
 	tsconfigName?: string;
 	typedocOptions?: Partial<TypeDocOptions>;
+
+	remarkPlugins: MDXPlugin[];
+	rehypePlugins: MDXPlugin[];
 
 	// Versioning, based on Docusaurus
 	disableVersioning?: boolean;


### PR DESCRIPTION
This PR adds support for remark and rehype plugins during MDX compilation.

Can this also be backported to a v3 release?