### PR TITLE
Support package categories

### DIFF
--- a/fixtures/monorepo-categories/deep-imports/CHANGELOG.md
+++ b/fixtures/monorepo-categories/deep-imports/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.0.4](https://github.com/foo/bar/compare/v3.0.3...v3.0.4) (2022-08-22)
+
+### Features
+
+* bump puppeteer support to 15.1
+
+
+### Bug Fixes
+
+* key value stores emitting an error when multiple write promises ran in parallel ([#1460](https://github.com/foo/bar/issues/1460)) ([f201cca](https://github.com/foo/bar/commit/f201cca4a99d1c8b3e87be0289d5b3b363048f09))
+* fix dockerfiles in project templates
+
+

--- a/fixtures/monorepo-categories/deep-imports/README.md
+++ b/fixtures/monorepo-categories/deep-imports/README.md
@@ -1,0 +1,6 @@
+# DEEP IMPORTS
+
+```yaml
+foo: 123
+bar: 'baz'
+```

--- a/fixtures/monorepo-categories/deep-imports/package.json
+++ b/fixtures/monorepo-categories/deep-imports/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "deep-imports",
+  "version": "1.0.0"
+}

--- a/fixtures/monorepo-categories/deep-imports/src/classes/Bar.ts
+++ b/fixtures/monorepo-categories/deep-imports/src/classes/Bar.ts
@@ -1,0 +1,1 @@
+export class Bar {}

--- a/fixtures/monorepo-categories/deep-imports/src/functions/foo.ts
+++ b/fixtures/monorepo-categories/deep-imports/src/functions/foo.ts
@@ -1,0 +1,1 @@
+export function foo() {}

--- a/fixtures/monorepo-categories/deep-imports/src/index.ts
+++ b/fixtures/monorepo-categories/deep-imports/src/index.ts
@@ -1,0 +1,1 @@
+export type Type = 'deep-imports';

--- a/fixtures/monorepo-categories/deep-imports/tsconfig.json
+++ b/fixtures/monorepo-categories/deep-imports/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declarationDir": "dts",
+    "outDir": "dts",
+    "rootDir": "src",
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "dts",
+    "tests"
+  ],
+  "extends": "../../../tsconfig.options.json",
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/fixtures/monorepo-categories/multi-imports/README.md
+++ b/fixtures/monorepo-categories/multi-imports/README.md
@@ -1,0 +1,7 @@
+# MULTI IMPORTS
+
+```json
+{
+  "foo": "bar"
+}
+```

--- a/fixtures/monorepo-categories/multi-imports/package.json
+++ b/fixtures/monorepo-categories/multi-imports/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "multi-imports",
+  "version": "1.0.0"
+}

--- a/fixtures/monorepo-categories/multi-imports/src/index.ts
+++ b/fixtures/monorepo-categories/multi-imports/src/index.ts
@@ -1,0 +1,1 @@
+export type Type = 'multi-imports';

--- a/fixtures/monorepo-categories/multi-imports/src/test.ts
+++ b/fixtures/monorepo-categories/multi-imports/src/test.ts
@@ -1,0 +1,1 @@
+export type Bar = 123;

--- a/fixtures/monorepo-categories/multi-imports/tsconfig.json
+++ b/fixtures/monorepo-categories/multi-imports/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declarationDir": "dts",
+    "outDir": "dts",
+    "rootDir": "src",
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "dts",
+    "tests"
+  ],
+  "extends": "../../../tsconfig.options.json",
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/fixtures/monorepo-categories/standard/README.md
+++ b/fixtures/monorepo-categories/standard/README.md
@@ -1,0 +1,7 @@
+# STANDARD
+
+```ts
+function foo(num: number) {
+  return 123;
+}
+```

--- a/fixtures/monorepo-categories/standard/package.json
+++ b/fixtures/monorepo-categories/standard/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "standard",
+  "version": "1.0.0"
+}

--- a/fixtures/monorepo-categories/standard/src/index.ts
+++ b/fixtures/monorepo-categories/standard/src/index.ts
@@ -1,0 +1,112 @@
+/**
+ * a type
+ * @beta
+ */
+export type Type = 'standard';
+
+/**
+ * short description
+ *
+ * long description with a link to {@link bizz}. did it work?
+ * what about our own tokens: {@apilink Foo} and {@doclink intro}!
+ * and some inline `code`???
+ *
+ * ```
+ * let dontForget = 'block code';
+ * ```
+ *
+ * @param {String} msg description
+ * @param other without type
+ * @returns returns the param
+ */
+export function comments(msg: string, other: boolean) {}
+
+/**
+ * newy new guy
+ * @param a a thing
+ * @param b b thing
+ * @alpha
+ */
+export function bizz(a: string, b: string): string;
+
+/**
+ * newy new guy
+ * @param a a thing
+ * @param b b thing
+ * @param c c thing
+ * @beta
+ */
+export function bizz(a: string, b: string, c: string): string;
+
+/**
+ * a thing for a thing
+ * @param a id
+ * @returns returns the param
+ * @beta
+ */
+export function bizz(...args: string[]): string {
+	return args[0];
+}
+
+/**
+ * @param {string} [a] thing
+ * @param {string} [b="b"] thing
+ * @param {string} [c="c override"] thing
+ */
+export function defs(a?: string, b?: string, c: string = 'c') {}
+
+/**
+ * thing for a thing
+ * @beta
+ */
+export interface Foo {
+	/**
+	 * very experimental
+	 * @alpha
+	 * @default "foo"
+	 */
+	foo: string;
+
+	/**
+	 * very experimental
+	 * @experimental
+	 */
+	a: string;
+
+	/**
+	 * @default 123
+	 */
+	int?: number;
+}
+
+/**
+ * :::
+ * standard
+ * :::
+ *
+ * :::note
+ * with type
+ * :::
+ *
+ * ::: title
+ * title only
+ * :::
+ *
+ * :::info title
+ * with type
+ *
+ * and title
+ * :::
+ *
+ * :::success
+ *
+ * extra new lines
+ *
+ * :::
+ */
+export function admonitions() {}
+
+/**
+ * @throws something
+ */
+export function errors() {}

--- a/fixtures/monorepo-categories/standard/tsconfig.json
+++ b/fixtures/monorepo-categories/standard/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declarationDir": "dts",
+    "outDir": "dts",
+    "rootDir": "src",
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "dts",
+    "tests"
+  ],
+  "extends": "../../../tsconfig.options.json",
+  "include": [
+    "src/**/*"
+  ],
+  "references": []
+}

--- a/fixtures/monorepo-categories/tsconfig.json
+++ b/fixtures/monorepo-categories/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.options.json",
+  "files": [],
+  "references": [
+    {
+      "path": "deep-imports"
+    },
+    {
+      "path": "multi-imports"
+    },
+    {
+      "path": "standard"
+    }
+  ]
+}

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -41,6 +41,7 @@ const DEFAULT_OPTIONS: Required<DocusaurusPluginTypeDocApiOptions> = {
 	onlyIncludeVersions: [],
 	packageJsonName: 'package.json',
 	packages: [],
+	packageCategories: [],
 	projectRoot: '.',
 	sortPackages: (a, d) => a.packageName.localeCompare(d.packageName),
 	sortSidebar: (a, d) => a.localeCompare(d),
@@ -89,7 +90,7 @@ export default function typedocApiPlugin(
 	// Determine entry points from configs
 	const entryPoints: string[] = [];
 	const packageConfigs: ResolvedPackageConfig[] = options.packages.map((pkgItem) => {
-		const pkgConfig = typeof pkgItem === 'string' ? { path: pkgItem } : pkgItem;
+		const pkgConfig = typeof pkgItem === 'string' ? { path: pkgItem, category: '' } : pkgItem;
 		const entries: Record<string, PackageEntryConfig> = {};
 
 		if (!pkgConfig.entry || typeof pkgConfig.entry === 'string') {
@@ -115,6 +116,7 @@ export default function typedocApiPlugin(
 
 		return {
 			entryPoints: entries,
+			category: pkgConfig.category,
 			packagePath: pkgConfig.path || '.',
 			packageSlug: pkgConfig.slug ?? path.basename(pkgConfig.path),
 			// Load later on
@@ -220,6 +222,7 @@ export default function typedocApiPlugin(
 								removeScopes,
 								changelogs,
 								options.sortSidebar,
+								options.packageCategories,
 							),
 						};
 					}),

--- a/packages/plugin/src/plugin/data.ts
+++ b/packages/plugin/src/plugin/data.ts
@@ -382,6 +382,7 @@ export function flattenAndGroupPackages(
 
 					packages[cfg.packagePath] = {
 						entryPoints: [],
+						category: cfg.category,
 						packageName: (versioned && cfg.packageName) || packageJson.name,
 						packageVersion: (versioned && cfg.packageVersion) || packageJson.version,
 						readmePath,

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -4,6 +4,7 @@ import type {
 	VersionBanner,
 	VersionsOptions,
 } from '@docusaurus/plugin-content-docs';
+import type { MDXPlugin } from '@docusaurus/mdx-loader';
 
 export type { VersionBanner };
 
@@ -20,6 +21,7 @@ export interface DocusaurusPluginTypeDocApiOptions
 	minimal?: boolean;
 	packageJsonName?: string;
 	packages: (PackageConfig | string)[];
+	packageCategories?: string[];
 	projectRoot: string;
 	readmeName?: string;
 	readmes?: boolean;
@@ -33,6 +35,9 @@ export interface DocusaurusPluginTypeDocApiOptions
 	disableVersioning?: boolean;
 	includeCurrentVersion?: boolean;
 	routeBasePath?: string;
+
+	remarkPlugins: MDXPlugin[];
+	rehypePlugins: MDXPlugin[];
 }
 
 // CONFIG
@@ -46,6 +51,7 @@ export interface PackageConfig {
 	path: string; // Folder relative to project root
 	entry?: Record<string, PackageEntryConfig | string> | string;
 	slug?: string;
+	category?: string;
 }
 
 export interface ResolvedPackageConfig {
@@ -54,6 +60,7 @@ export interface ResolvedPackageConfig {
 	packageSlug: string;
 	packageName: string;
 	packageVersion: string;
+	category: string;
 }
 
 // VERSIONING
@@ -113,6 +120,7 @@ export interface PackageReflectionGroup {
 	packageVersion: string;
 	changelogPath?: string;
 	readmePath?: string;
+	category: string;
 }
 
 export interface ApiMetadata {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -37,6 +37,27 @@ const monorepoOnePackage = {
 	packages: ['standard'],
 };
 
+const monorepoCategories = {
+	projectRoot: path.join(__dirname, '../fixtures/monorepo'),
+	packages: [
+		{
+			path: 'deep-imports',
+			entry: 'src/',
+			category: 'Deep imports',
+		},
+		{
+			category: 'Multi imports',
+			path: 'multi-imports',
+			entry: {
+				index: 'src/index.ts',
+				test: { path: 'src/test.ts', label: 'Test utilities' },
+			},
+		},
+		'standard',
+	],
+	categories: ['Multi imports', 'Deep imports'],
+};
+
 // POLYREPO STANDARD
 const polyrepo = {
 	projectRoot: path.join(__dirname, '../fixtures/polyrepo'),
@@ -122,6 +143,8 @@ function getPluginConfig() {
 			return monorepo;
 		case 'monorepo-1':
 			return monorepoOnePackage;
+		case 'monorepo-categories':
+			return monorepoCategories;
 		case 'polyrepo':
 			return polyrepo;
 		case 'polyrepo-deep':


### PR DESCRIPTION
Port code from `yarn`'s patch: https://github.com/yarnpkg/berry/blob/master/.yarn/patches/docusaurus-plugin-typedoc-api-npm-3.0.1-7dd061feb2.patch

References
===
- Yarn's use of docusaurus-plugin-typedoc-api, which they enhance to support categorizing packages in a monomrepo: https://yarnpkg.com/api (i.e. "Generic Packages", "Yarn Packages",  "Default Plugins")

Additional
===
- Because this was a port of `yarn`'s patch, this includes other features they've added such as the `rehype` and `remark` plugins support. This overlaps with https://github.com/milesj/docusaurus-plugin-typedoc-api/pull/123 -- I'm happy to work on removing it from this PR if this is requested.