### PR TITLE
internal: Improve mdx-loader usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "clean": "packemon clean --cwd packages/plugin",
     "docs": "yarn run build && cd website && yarn run start",
     "build": "packemon build --addEngines --cwd packages/plugin",
-    "pack": "rm -f packages/plugin/tsconfig.lib.tsbuildinfo && packemon pack --addEngines --declaration --cwd packages/plugin",
+    "pack": "rimraf packages/plugin/tsconfig.lib.tsbuildinfo && packemon pack --addEngines --declaration --cwd packages/plugin",
     "format": "prettier --write .",
     "lint": "eslint --cache --color --fix --ext .ts,.tsx ./packages/*/{src,tests} ./website/src",
     "type": "tsc --build",
@@ -23,6 +23,7 @@
     "prettier": "^3.2.4",
     "prettier-config-moon": "^1.1.2",
     "react": "^18.2.0",
+    "rimraf": "^5.0.5",
     "tsconfig-moon": "^1.3.0",
     "typescript": "^5.3.3"
   },

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -41,6 +41,7 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.0",
+    "@docusaurus/mdx-loader": "^3.0.0",
     "react": ">=18.0.0",
     "typescript": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7353,6 +7353,7 @@ __metadata:
     prettier: "npm:^3.2.4"
     prettier-config-moon: "npm:^1.1.2"
     react: "npm:^18.2.0"
+    rimraf: "npm:^5.0.5"
     tsconfig-moon: "npm:^1.3.0"
     typescript: "npm:^5.3.3"
   languageName: unknown
@@ -7376,6 +7377,7 @@ __metadata:
     typescript: "npm:^5.3.3"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
+    "@docusaurus/mdx-loader": ^3.0.0
     react: ">=18.0.0"
     typescript: ^5.0.0
   languageName: unknown
@@ -9188,6 +9190,21 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: e5c3c1b2079a30969267cb271f5cd6654c1e1a4774b88fc75f6ddb3fb15ece02b4a8c9ff913a6fd83beebd7972b8268d80d65387684be3ca0121bc9490027efa
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.3.7":
+  version: 10.3.10
+  resolution: "glob@npm:10.3.10"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^2.3.5"
+    minimatch: "npm:^9.0.1"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+    path-scurry: "npm:^1.10.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 38bdb2c9ce75eb5ed168f309d4ed05b0798f640b637034800a6bf306f39d35409bf278b0eaaffaec07591085d3acb7184a201eae791468f0f617771c2486a6a8
   languageName: node
   linkType: hard
 
@@ -15820,6 +15837,17 @@ __metadata:
   bin:
     rimraf: dist/cjs/src/bin.js
   checksum: 218ef9122145ccce9d0a71124d36a3894537de46600b37fae7dba26ccff973251eaa98aa63c2c5855a05fa04bca7cbbd7a92d4b29f2875d2203e72530ecf6ede
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:^5.0.5":
+  version: 5.0.5
+  resolution: "rimraf@npm:5.0.5"
+  dependencies:
+    glob: "npm:^10.3.7"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: a612c7184f96258b7d1328c486b12ca7b60aa30e04229a08bbfa7e964486deb1e9a1b52d917809311bdc39a808a4055c0f950c0280fba194ba0a09e6f0d404f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Explicitly require mdx loader as an optional peer dependency.

Added rimraf as a dev dependency to enable cross platform removal of the tsconfig.lib.tsbuildinfo file, and thus cross platform builds.

Fix configuration to satisfy the mdx loader's options (specifically, the static folders and site dir).

Adjusted the whitelisting to only include files that are enabled, rather than include both if either changelogs or readmes are enabled.

Removed an unnecessary await in extractSidebar call.


----


I'm not 100% sure about the siteDir config, but then again, it's required, so _something_ should be put there. Just not sure if copying the global siteDir is correct, or if some context/config/package specific folder is the correct path.