### PR TITLE
fix: Fix for reported broken links.

### DIFF
--- a/packages/plugin/src/components/AnchorLink.tsx
+++ b/packages/plugin/src/components/AnchorLink.tsx
@@ -1,12 +1,17 @@
+import Link from '@docusaurus/Link';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
+
 export interface AnchorLinkProps {
 	id: string;
 }
 
 export function AnchorLink({ id }: AnchorLinkProps) {
+	useBrokenLinks().collectAnchor(id);
+
 	return (
-		<a className="tsd-anchor" href={`#${id}`}>
+		<Link className="tsd-anchor" href={`#${id}`}>
 			<span className="tsd-anchor-id" id={id} />
 			<i className="codicon codicon-symbol-numeric" />
-		</a>
+		</Link>
 	);
 }


### PR DESCRIPTION
When running Docusaurus with this plugin, all links are erroneously reported as broken. That's because "id" attributes on vanilla HTML elements are not automatically collected by Docusaurus. This PR fixes that by informing Docusaurus about the new anchor (the span with the id attribute) generated by the AnchorLink component.

And also I switched out the vanilla "a" for Docusaurus' Link component, for consistency mostly.