### PR TITLE
fix: Support for Object Literals and Destructed Parameters in @param [#147]

### DIFF
--- a/packages/plugin/src/components/MemberSignatureBody.tsx
+++ b/packages/plugin/src/components/MemberSignatureBody.tsx
@@ -87,70 +87,70 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 					<ul className="tsd-parameters">
 						{sig.parameters?.map((param) => (
 							<Fragment key={param.id}>
-							<li>
-								<h5>
-									<Flags flags={param.flags} />
-									{param.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
-									{`${param.name}: `}
-									<Type type={param.type} />
-									<DefaultValue
-										comment={param.comment}
-										type={param.type}
-										value={param.defaultValue}
-									/>
-								</h5>
+								<li>
+									<h5>
+										<Flags flags={param.flags} />
+										{param.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
+										{`${param.name}: `}
+										<Type type={param.type} />
+										<DefaultValue
+											comment={param.comment}
+											type={param.type}
+											value={param.defaultValue}
+										/>
+									</h5>
 
-								<Comment comment={param.comment} />
-							</li>
+									<Comment comment={param.comment} />
+								</li>
 
-							{param.type.type === 'reflection' && (
-								<ul key={param.type.declaration.id}>
-									{param.type.declaration.children.map((reflectionChild) => (
-										<li key={reflectionChild.id}>
-											<h5>
-												<Flags flags={reflectionChild.flags} />
-												{reflectionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
-												{`${reflectionChild.name}: `}
-												<Type type={reflectionChild.type} />
-												<DefaultValue
-													comment={reflectionChild.comment as unknown as JSONOutput.Comment}
-													type={reflectionChild.type}
-													value={reflectionChild.defaultValue}
-												/>
-											</h5>
+								{param.type?.type === 'reflection' && (
+									<ul key={param.type.declaration.id}>
+										{param.type.declaration?.children?.map((reflectionChild) => (
+											<li key={reflectionChild.id}>
+												<h5>
+													<Flags flags={reflectionChild.flags} />
+													{reflectionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
+													{`${reflectionChild.name}: `}
+													<Type type={reflectionChild.type} />
+													<DefaultValue
+														comment={reflectionChild.comment as unknown as JSONOutput.Comment}
+														type={reflectionChild.type}
+														value={reflectionChild.defaultValue}
+													/>
+												</h5>
 
-											<Comment comment={reflectionChild.comment as unknown as JSONOutput.Comment} />
-										</li>
-									))}
-								</ul>
-							)}
+												<Comment comment={reflectionChild.comment as unknown as JSONOutput.Comment} />
+											</li>
+										))}
+									</ul>
+								)}
 
-							{param.type.type === 'union' && (
-								(param.type as unknown as Models.UnionType).types.filter(
-									(unionType) => unionType.type === 'reflection').map(
-									(unionReflectionType: Models.ReflectionType) => (
-										<ul key={unionReflectionType.declaration.id}>
-											{unionReflectionType.declaration.children.map((unionChild) => (
-												<li key={unionChild.id}>
-													<h5>
-														<Flags flags={unionChild.flags} />
-														{unionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
-														{`${unionChild.name}: `}
-														<Type type={unionChild.type} />
-														<DefaultValue
-															comment={unionChild.comment as unknown as JSONOutput.Comment}
-															type={unionChild.type}
-															value={unionChild.defaultValue}
-														/>
-													</h5>
+								{param.type?.type === 'union' && (
+									(param.type as unknown as Models.UnionType).types.filter(
+										(unionType) => unionType.type === 'reflection').map(
+										(unionReflectionType) => (
+											<ul key={(unionReflectionType as Models.ReflectionType).declaration.id}>
+												{(unionReflectionType as Models.ReflectionType).declaration?.children?.map((unionChild) => (
+													<li key={unionChild.id}>
+														<h5>
+															<Flags flags={unionChild.flags} />
+															{unionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
+															{`${unionChild.name}: `}
+															<Type type={unionChild.type} />
+															<DefaultValue
+																comment={unionChild.comment as unknown as JSONOutput.Comment}
+																type={unionChild.type}
+																value={unionChild.defaultValue}
+															/>
+														</h5>
 
-													<Comment comment={unionChild.comment as unknown as JSONOutput.Comment} />
-												</li>
-											))}
-										</ul>
-									))
-							)}
-						</Fragment>
+														<Comment comment={unionChild.comment as unknown as JSONOutput.Comment} />
+													</li>
+												))}
+											</ul>
+										))
+								)}
+							</Fragment>
 						))}
 					</ul>
 				</>

--- a/packages/plugin/src/components/MemberSignatureBody.tsx
+++ b/packages/plugin/src/components/MemberSignatureBody.tsx
@@ -1,6 +1,7 @@
 // https://github.com/TypeStrong/typedoc-default-themes/blob/master/src/default/partials/member.signature.body.hbs
 
-import type { JSONOutput } from 'typedoc';
+import { Fragment } from 'react'
+import type { JSONOutput, Models } from 'typedoc';
 import { useMinimalLayout } from '../hooks/useMinimalLayout';
 import type { TSDSignatureReflection } from '../types';
 import { Comment, hasComment } from './Comment';
@@ -85,7 +86,8 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 
 					<ul className="tsd-parameters">
 						{sig.parameters?.map((param) => (
-							<li key={param.id}>
+							<Fragment key={param.id}>
+							<li>
 								<h5>
 									<Flags flags={param.flags} />
 									{param.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
@@ -100,6 +102,55 @@ export function MemberSignatureBody({ hideSources, sig }: MemberSignatureBodyPro
 
 								<Comment comment={param.comment} />
 							</li>
+
+							{param.type.type === 'reflection' && (
+								<ul key={param.type.declaration.id}>
+									{param.type.declaration.children.map((reflectionChild) => (
+										<li key={reflectionChild.id}>
+											<h5>
+												<Flags flags={reflectionChild.flags} />
+												{reflectionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
+												{`${reflectionChild.name}: `}
+												<Type type={reflectionChild.type} />
+												<DefaultValue
+													comment={reflectionChild.comment as unknown as JSONOutput.Comment}
+													type={reflectionChild.type}
+													value={reflectionChild.defaultValue}
+												/>
+											</h5>
+
+											<Comment comment={reflectionChild.comment as unknown as JSONOutput.Comment} />
+										</li>
+									))}
+								</ul>
+							)}
+
+							{param.type.type === 'union' && (
+								(param.type as unknown as Models.UnionType).types.filter(
+									(unionType) => unionType.type === 'reflection').map(
+									(unionReflectionType: Models.ReflectionType) => (
+										<ul key={unionReflectionType.declaration.id}>
+											{unionReflectionType.declaration.children.map((unionChild) => (
+												<li key={unionChild.id}>
+													<h5>
+														<Flags flags={unionChild.flags} />
+														{unionChild.flags?.isRest && <span className="tsd-signature-symbol">...</span>}
+														{`${unionChild.name}: `}
+														<Type type={unionChild.type} />
+														<DefaultValue
+															comment={unionChild.comment as unknown as JSONOutput.Comment}
+															type={unionChild.type}
+															value={unionChild.defaultValue}
+														/>
+													</h5>
+
+													<Comment comment={unionChild.comment as unknown as JSONOutput.Comment} />
+												</li>
+											))}
+										</ul>
+									))
+							)}
+						</Fragment>
 						))}
 					</ul>
 				</>


### PR DESCRIPTION
This PR fixes the issue in #147 
It further extends the rendering of `@param` to identify if there are more children in `reflection` type or `union` type.