### PR TITLE
feat: Support for Page Options - Hide Inherited [#150]

### DIFF
--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -1,4 +1,4 @@
-import { createContext, useMemo, useState } from 'react'
+import { createContext, useMemo, useState } from 'react';
 import { PageMetadata } from '@docusaurus/theme-common';
 import type { Props as DocItemProps } from '@theme/DocItem';
 import { useReflection, useRequiredReflection } from '../hooks/useReflection';
@@ -7,7 +7,7 @@ import type { TOCItem, TSDDeclarationReflection, TSDDeclarationReflectionMap } f
 import { escapeMdx } from '../utils/helpers';
 import { getKindIconHtml } from '../utils/icons';
 import ApiItemLayout from './ApiItemLayout';
-import ApiOptionsLayout from './ApiOptionsLayout'
+import ApiOptionsLayout from './ApiOptionsLayout';
 import { displayPartsToMarkdown } from './Comment';
 import { Flags } from './Flags';
 import { Reflection } from './Reflection';

--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -7,7 +7,6 @@ import type { TOCItem, TSDDeclarationReflection, TSDDeclarationReflectionMap } f
 import { escapeMdx } from '../utils/helpers';
 import { getKindIconHtml } from '../utils/icons';
 import ApiItemLayout from './ApiItemLayout';
-import ApiOptionsLayout from './ApiOptionsLayout';
 import { displayPartsToMarkdown } from './Comment';
 import { Flags } from './Flags';
 import { Reflection } from './Reflection';
@@ -93,8 +92,6 @@ export default function ApiItem({ readme: Readme, route }: ApiItemProps) {
 
 	return (
 		<ApiOptionsContext.Provider value={apiOptions}>
-			<ApiOptionsLayout />
-
 			<ApiItemLayout
 				heading={
 					<>

--- a/packages/plugin/src/components/ApiItemLayout.tsx
+++ b/packages/plugin/src/components/ApiItemLayout.tsx
@@ -14,6 +14,7 @@ import TOC from '@theme/TOC';
 import TOCCollapsible from '@theme/TOCCollapsible';
 import { useBreadcrumbs } from '../hooks/useBreadcrumbs';
 import type { TOCItem } from '../types';
+import ApiOptionsLayout from './ApiOptionsLayout'
 import { Footer } from './Footer';
 import { VersionBanner } from './VersionBanner';
 
@@ -54,12 +55,15 @@ export default function ApiItemLayout({
 							<DocVersionBadge />
 
 							{canRenderTOC && (
-								<TOCCollapsible
-									className={`${ThemeClassNames.docs.docTocMobile ?? ''} apiTocMobile`}
-									maxHeadingLevel={6}
-									minHeadingLevel={1}
-									toc={toc}
-								/>
+								<>
+									{!renderTocDesktop && <ApiOptionsLayout className="tsd-api-options-mobile" />}
+									<TOCCollapsible
+										className={`${ThemeClassNames.docs.docTocMobile ?? ''} apiTocMobile`}
+										maxHeadingLevel={6}
+										minHeadingLevel={1}
+										toc={toc}
+									/>
+								</>
 							)}
 
 							<div className={`${ThemeClassNames.docs.docMarkdown ?? ''} markdown`}>
@@ -79,6 +83,7 @@ export default function ApiItemLayout({
 
 				{renderTocDesktop && (
 					<div className="col col--3">
+						<ApiOptionsLayout className="tsd-api-options" />
 						<TOC
 							className={ThemeClassNames.docs.docTocDesktop}
 							maxHeadingLevel={6}

--- a/packages/plugin/src/components/ApiOptionsLayout.tsx
+++ b/packages/plugin/src/components/ApiOptionsLayout.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import { ApiOptionsContext } from './ApiItem';
 
-export default function ApiOptionsLayout() {
+export default function ApiOptionsLayout({ className }: { className: string }) {
   const { hideInherited, setHideInherited } = useContext(ApiOptionsContext);
   const handleHideInherited = useCallback(() => {
     setHideInherited(!hideInherited);
@@ -9,12 +9,13 @@ export default function ApiOptionsLayout() {
 
   return (
     <>
-      <div className="tsd-api-options">
+      <div className={className}>
         <div><b>Page Options</b></div>
         <label>
           <input checked={hideInherited} type="checkbox" onChange={handleHideInherited} />
           <span>Hide Inherited</span>
         </label>
+        <div />
       </div>
     </>
   );

--- a/packages/plugin/src/components/ApiOptionsLayout.tsx
+++ b/packages/plugin/src/components/ApiOptionsLayout.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useContext } from 'react'
-import { ApiOptionsContext } from './ApiItem'
+import { useCallback, useContext } from 'react';
+import { ApiOptionsContext } from './ApiItem';
 
 export default function ApiOptionsLayout() {
   const { hideInherited, setHideInherited } = useContext(ApiOptionsContext);

--- a/packages/plugin/src/components/ApiOptionsLayout.tsx
+++ b/packages/plugin/src/components/ApiOptionsLayout.tsx
@@ -1,0 +1,17 @@
+import { useCallback, useContext } from 'react'
+import { ApiOptionsContext } from './ApiItem'
+
+export default function ApiOptionsLayout() {
+  const { hideInherited, setHideInherited } = useContext(ApiOptionsContext);
+  const handleHideInherited = useCallback(() => {
+    setHideInherited(!hideInherited);
+  }, [hideInherited, setHideInherited]);
+
+  return (
+    <>
+      <div>
+        <input checked={hideInherited} type="checkbox" onChange={handleHideInherited} />
+      </div>
+    </>
+  );
+}

--- a/packages/plugin/src/components/ApiOptionsLayout.tsx
+++ b/packages/plugin/src/components/ApiOptionsLayout.tsx
@@ -9,8 +9,12 @@ export default function ApiOptionsLayout() {
 
   return (
     <>
-      <div>
-        <input checked={hideInherited} type="checkbox" onChange={handleHideInherited} />
+      <div className="tsd-api-options">
+        <div><b>Page Options</b></div>
+        <label>
+          <input checked={hideInherited} type="checkbox" onChange={handleHideInherited} />
+          <span>Hide Inherited</span>
+        </label>
       </div>
     </>
   );

--- a/packages/plugin/src/components/Member.tsx
+++ b/packages/plugin/src/components/Member.tsx
@@ -1,12 +1,13 @@
 // https://github.com/TypeStrong/typedoc-default-themes/blob/master/src/default/partials/members.hbs
 
-import { Fragment } from 'react';
+import { Fragment, useContext } from 'react'
 import type { JSONOutput } from 'typedoc';
 import { useRequiredReflection } from '../hooks/useReflection';
 import { useReflectionMap } from '../hooks/useReflectionMap';
 import { escapeMdx } from '../utils/helpers';
 import { hasOwnDocument } from '../utils/visibility';
 import { AnchorLink } from './AnchorLink';
+import { ApiOptionsContext } from './ApiItem'
 import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Flags } from './Flags';
 import { MemberDeclaration } from './MemberDeclaration';
@@ -25,6 +26,9 @@ export function Member({ id }: MemberProps) {
 	const { comment } = reflection;
 	let content: React.ReactNode = null;
 
+	const apiOptions = useContext(ApiOptionsContext);
+	const shouldHideInherited = reflection.inheritedFrom ? apiOptions.hideInherited : false;
+
 	if (reflection.signatures) {
 		content = <MemberSignatures inPanel sigs={reflection.signatures} />;
 	} else if (reflection.getSignature || reflection.setSignature) {
@@ -42,7 +46,7 @@ export function Member({ id }: MemberProps) {
 	}
 
 	return (
-		<section className="tsd-panel tsd-member">
+		!shouldHideInherited && <section className="tsd-panel tsd-member">
 			<h3 className="tsd-panel-header">
 				<AnchorLink id={reflection.name} />
 				<SourceLink sources={reflection.sources} />

--- a/packages/plugin/src/components/Member.tsx
+++ b/packages/plugin/src/components/Member.tsx
@@ -1,13 +1,13 @@
 // https://github.com/TypeStrong/typedoc-default-themes/blob/master/src/default/partials/members.hbs
 
-import { Fragment, useContext } from 'react'
+import { Fragment, useContext } from 'react';
 import type { JSONOutput } from 'typedoc';
 import { useRequiredReflection } from '../hooks/useReflection';
 import { useReflectionMap } from '../hooks/useReflectionMap';
 import { escapeMdx } from '../utils/helpers';
 import { hasOwnDocument } from '../utils/visibility';
 import { AnchorLink } from './AnchorLink';
-import { ApiOptionsContext } from './ApiItem'
+import { ApiOptionsContext } from './ApiItem';
 import { CommentBadges, isCommentWithModifiers } from './CommentBadges';
 import { Flags } from './Flags';
 import { MemberDeclaration } from './MemberDeclaration';

--- a/packages/plugin/src/components/styles.css
+++ b/packages/plugin/src/components/styles.css
@@ -7,19 +7,47 @@
 }
 
 .tsd-api-options {
-	border-bottom: 1px solid #eee;
+	border-left: 1px solid var(--ifm-toc-border-color);
 	font-size: var(--tsd-font-small);
-	margin-bottom: 10px;
-	margin-right: 10px;
-	padding-bottom: 10px;
-	text-align: right;
+	padding-left: var(--ifm-toc-padding-horizontal);
+}
+.tsd-api-options > div:first-child {
+	margin: var(--ifm-toc-padding-vertical) var(--ifm-toc-padding-horizontal);
+}
+.tsd-api-options > label {
+	margin: var(--ifm-toc-padding-vertical) var(--ifm-toc-padding-horizontal);
 }
 .tsd-api-options > label > input {
-	margin-right: 5px;
+	margin: 0 5px 0 0;
 	vertical-align: middle;
 }
 .tsd-api-options > label > span {
 	vertical-align: middle;
+}
+.tsd-api-options > div:last-child {
+	border-bottom: 1px solid var(--ifm-toc-border-color);
+	margin-top: 1rem;
+}
+
+.tsd-api-options-mobile {
+	font-size: var(--tsd-font-small);
+}
+.tsd-api-options-mobile > div:first-child {
+	margin: var(--ifm-toc-padding-vertical) var(--ifm-toc-padding-horizontal);
+}
+.tsd-api-options-mobile > label {
+	margin: var(--ifm-toc-padding-vertical) var(--ifm-toc-padding-horizontal);
+}
+.tsd-api-options-mobile > label > input {
+	margin: 0 5px 0 0;
+	vertical-align: middle;
+}
+.tsd-api-options-mobile > label > span {
+	vertical-align: middle;
+}
+.tsd-api-options-mobile > div:last-child {
+	border-bottom: 1px solid var(--ifm-toc-border-color);
+	margin-top: 1rem;
 }
 
 .tsd-panel {

--- a/packages/plugin/src/components/styles.css
+++ b/packages/plugin/src/components/styles.css
@@ -6,6 +6,22 @@
 	--tsd-spacing-horizontal: 1rem;
 }
 
+.tsd-api-options {
+	border-bottom: 1px solid #eee;
+	font-size: var(--tsd-font-small);
+	margin-bottom: 10px;
+	margin-right: 10px;
+	padding-bottom: 10px;
+	text-align: right;
+}
+.tsd-api-options > label > input {
+	margin-right: 5px;
+	vertical-align: middle;
+}
+.tsd-api-options > label > span {
+	vertical-align: middle;
+}
+
 .tsd-panel {
 	border: 1px solid var(--ifm-card-background-color);
 	border-radius: var(--ifm-global-radius);


### PR DESCRIPTION
This PR is to add support for page options, the first one including `Hide Inherited` as explained in #150 .

As shown in screenshot, at the top of the page you can see a new option - Page Options.

<br />
When unchecked (default), the page would show normally.
<img width="1433" alt="Screenshot 2024-08-03 at 2 15 51 PM" src="https://github.com/user-attachments/assets/ce649403-1494-4d30-a44c-616b7ea3a602">

<br /><br />
When checked, all attributes that were inherited, in sidebar and in page content, are hidden.
<img width="1433" alt="Screenshot 2024-08-03 at 2 15 59 PM" src="https://github.com/user-attachments/assets/1e8ea578-0092-4298-9c92-167c77d36cb2">
