### PR TITLE
feat: Support for reference tag [#153]

### DIFF
--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import type { InlineTagDisplayPart } from 'typedoc'
 import { PageMetadata } from '@docusaurus/theme-common';
 import type { Props as DocItemProps } from '@theme/DocItem';
 import { useReflection, useRequiredReflection } from '../hooks/useReflection';
@@ -48,6 +49,7 @@ export interface ApiItemProps extends Pick<DocItemProps, 'route'> {
 	readme?: React.ComponentType;
 }
 
+// eslint-disable-next-line complexity
 export default function ApiItem({ readme: Readme, route }: ApiItemProps) {
 	const item = useRequiredReflection((route as unknown as { id: number }).id);
 	const reflections = useReflectionMap();
@@ -73,6 +75,37 @@ export default function ApiItem({ readme: Readme, route }: ApiItemProps) {
 		}),
 		[nextItem, prevItem],
 	);
+
+	// Add @reference categories.
+	const referenceCategories: Record<string, { title: string; children: number[] }> = {};
+	for (const tag of item.comment?.blockTags ?? []) {
+		if (tag.tag === '@reference' && tag.content.length >= 2 && tag.content[0].kind === 'text') {
+			const categoryName = tag.content[0].text.trim();
+			const ref = (tag.content as InlineTagDisplayPart[]).find((t) => t.tag === '@link');
+
+			if (ref && typeof ref.target === 'number') {
+				if (!(categoryName in referenceCategories)) {
+					referenceCategories[categoryName] = { title: categoryName, children: [] };
+				}
+
+				if (!referenceCategories[categoryName].children.includes(ref.target)) {
+					referenceCategories[categoryName].children.push(ref.target);
+				}
+			}
+		}
+	}
+
+	if (!item.categories) {
+		item.categories = [];
+	}
+	for (const category of Object.values(referenceCategories)) {
+		if (category.children.length > 0) {
+			const index = item.categories.findIndex((c) => c.title === category.title);
+			if (index === -1) {
+				item.categories.push(category);
+			}
+		}
+	}
 
 	return (
 		<ApiItemLayout

--- a/packages/plugin/src/components/ApiItem.tsx
+++ b/packages/plugin/src/components/ApiItem.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import type { InlineTagDisplayPart } from 'typedoc'
 import { PageMetadata } from '@docusaurus/theme-common';
 import type { Props as DocItemProps } from '@theme/DocItem';
 import { useReflection, useRequiredReflection } from '../hooks/useReflection';
@@ -49,7 +48,6 @@ export interface ApiItemProps extends Pick<DocItemProps, 'route'> {
 	readme?: React.ComponentType;
 }
 
-// eslint-disable-next-line complexity
 export default function ApiItem({ readme: Readme, route }: ApiItemProps) {
 	const item = useRequiredReflection((route as unknown as { id: number }).id);
 	const reflections = useReflectionMap();
@@ -75,37 +73,6 @@ export default function ApiItem({ readme: Readme, route }: ApiItemProps) {
 		}),
 		[nextItem, prevItem],
 	);
-
-	// Add @reference categories.
-	const referenceCategories: Record<string, { title: string; children: number[] }> = {};
-	for (const tag of item.comment?.blockTags ?? []) {
-		if (tag.tag === '@reference' && tag.content.length >= 2 && tag.content[0].kind === 'text') {
-			const categoryName = tag.content[0].text.trim();
-			const ref = (tag.content as InlineTagDisplayPart[]).find((t) => t.tag === '@link');
-
-			if (ref && typeof ref.target === 'number') {
-				if (!(categoryName in referenceCategories)) {
-					referenceCategories[categoryName] = { title: categoryName, children: [] };
-				}
-
-				if (!referenceCategories[categoryName].children.includes(ref.target)) {
-					referenceCategories[categoryName].children.push(ref.target);
-				}
-			}
-		}
-	}
-
-	if (!item.categories) {
-		item.categories = [];
-	}
-	for (const category of Object.values(referenceCategories)) {
-		if (category.children.length > 0) {
-			const index = item.categories.findIndex((c) => c.title === category.title);
-			if (index === -1) {
-				item.categories.push(category);
-			}
-		}
-	}
 
 	return (
 		<ApiItemLayout

--- a/packages/plugin/src/components/Comment.tsx
+++ b/packages/plugin/src/components/Comment.tsx
@@ -37,7 +37,7 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 		return null;
 	}
 
-  // Hide custom tags.
+	// Hide custom tags.
 	hideTags.push('@reference');
 
 	const blockTags =

--- a/packages/plugin/src/components/Comment.tsx
+++ b/packages/plugin/src/components/Comment.tsx
@@ -37,6 +37,9 @@ export function Comment({ comment, root, hideTags = [] }: CommentProps) {
 		return null;
 	}
 
+  // Hide custom tags.
+	hideTags.push('@reference');
+
 	const blockTags =
 		comment.blockTags?.filter((tag) => {
 			if (hideTags.includes(tag.tag)) {


### PR DESCRIPTION
This PR adds support to show `@reference` tag, which is a custom tag, as discussed in #153 

You can use this tag as `@reference <Name> {@link <Exported class>}`

E.g.
```ts
/**
This is class A and does blah.

@reference Resources {@link B}
@reference Models {@link C}
*/
class A {
  ...
}
```

It would look like,
<img width="848" alt="Screenshot 2024-08-03 at 11 38 27 PM" src="https://github.com/user-attachments/assets/a43d6edb-4835-4c2e-9358-e5b195faf367">

If your IDE complains about using `@reference` tag, which is a custom tag not supported in TypeDoc, then you will need to extend their schema definition by putting a new `tsdoc.json` in the root of your directory.
```json
{
    "$schema": "https://developer.microsoft.com/en-us/json-schemas/tsdoc/v0/tsdoc.schema.json",
    "extends": ["typedoc/tsdoc.json"],
    "noStandardTags": false,
    "tagDefinitions": [
        {
            "tagName": "@reference",
            "syntaxKind": "block",
            "allowMultiple": true
        }
    ]
}
```