### PR TITLE
chore: normalize package repository metadata

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -34,3 +34,31 @@
     "platform": "node",
     "externals": [
       "@theme/*",
+      "@docusaurus/*",
+      "@vscode/*",
+      "css$"
+    ]
+  },
+  "peerDependencies": {
+    "@docusaurus/core": "^3.5.0",
+    "@docusaurus/mdx-loader": "^3.5.0",
+    "react": ">=18.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "@docusaurus/plugin-content-docs": "^3.5.0",
+    "@docusaurus/types": "^3.5.0",
+    "@docusaurus/utils": "^3.5.0",
+    "@vscode/codicons": "^0.0.36",
+    "marked": "^9.1.6",
+    "marked-smartypants": "^1.1.5",
+    "typedoc": "^0.25.7"
+  },
+  "devDependencies": {
+    "@docusaurus/module-type-aliases": "^3.5.0",
+    "@docusaurus/tsconfig": "^3.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:milesj/docusaurus-plugin-typedoc-api.git"
+    "url": "git+https://github.com/milesj/docusaurus-plugin-typedoc-api.git"
   },
   "author": "Miles Johnson",
   "license": "MIT",
@@ -34,31 +34,3 @@
     "platform": "node",
     "externals": [
       "@theme/*",
-      "@docusaurus/*",
-      "@vscode/*",
-      "css$"
-    ]
-  },
-  "peerDependencies": {
-    "@docusaurus/core": "^3.5.0",
-    "@docusaurus/mdx-loader": "^3.5.0",
-    "react": ">=18.0.0",
-    "typescript": "^5.0.0"
-  },
-  "dependencies": {
-    "@docusaurus/plugin-content-docs": "^3.5.0",
-    "@docusaurus/types": "^3.5.0",
-    "@docusaurus/utils": "^3.5.0",
-    "@vscode/codicons": "^0.0.36",
-    "marked": "^9.1.6",
-    "marked-smartypants": "^1.1.5",
-    "typedoc": "^0.25.7"
-  },
-  "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.5.0",
-    "@docusaurus/tsconfig": "^3.5.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.5.4"
-  }
-}


### PR DESCRIPTION
## Summary
- Replace the published package repository URL with a public HTTPS Git URL.

## Verification
- Confirmed the compare diff only changes the repository URL in packages/plugin/package.json.
